### PR TITLE
Make `as_str` unchecked; Add `as_str_mut`, some convenience functions, and standard traits

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,13 +1,19 @@
 [![MIT license](https://img.shields.io/github/license/RCasatta/e-write-buffer)](https://github.com/RCasatta/e-write-buffer/blob/master/LICENSE)
 [![Crates](https://img.shields.io/crates/v/e-write-buffer.svg)](https://crates.io/crates/e-write-buffer)
+[![Released API docs](https://docs.rs/stm32f1xx-hal/badge.svg)](https://docs.rs/stm32f1xx-hal)
 
-A no-std `Write`able buffer, to use like
+A `no_std`, no allocation, `core::fmt::Write`able buffer.
 
- ```
+Usage:
+
+```rs
 use e_write_buffer::WriteBuffer;
-use std::fmt::Write;
-let mut buffer: WriteBuffer<20> = WriteBuffer::new();
-let x = 12;
-write!(buffer, "{}", x).expect("Can't write");
-assert_eq!(buffer.as_str().unwrap(), "12");
+use std::fmt::Write as _;
+
+fn main() {
+    let mut buffer: WriteBuffer<20> = WriteBuffer::new();
+    let x = 12;
+    write!(buffer, "{}", x).unwrap();
+    assert_eq!(buffer.as_str(), "12");
+}
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 [![MIT license](https://img.shields.io/github/license/RCasatta/e-write-buffer)](https://github.com/RCasatta/e-write-buffer/blob/master/LICENSE)
 [![Crates](https://img.shields.io/crates/v/e-write-buffer.svg)](https://crates.io/crates/e-write-buffer)
-[![Released API docs](https://docs.rs/stm32f1xx-hal/badge.svg)](https://docs.rs/stm32f1xx-hal)
+[![Released API docs](https://docs.rs/e-write-buffer/badge.svg)](https://docs.rs/e-write-buffer)
 
 A `no_std`, no allocation, `core::fmt::Write`able buffer.
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,9 @@
+use e_write_buffer::WriteBuffer;
+use std::fmt::Write as _;
+
+fn main() {
+    let mut buffer: WriteBuffer<20> = WriteBuffer::new();
+    let x = 12;
+    write!(buffer, "{}", x).unwrap();
+    assert_eq!(buffer.as_str(), "12");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 use core::fmt::{self, Display, Formatter};
 
 /// A write buffer
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WriteBuffer<const N: usize> {
     buffer: [u8; N],
     cursor: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,17 @@
 //! 
 //! Usage:
 //!
-//! ```
+//! ```rs
 //! use e_write_buffer::WriteBuffer;
-//! use std::fmt::Write;
-//! let mut buffer: WriteBuffer<20> = WriteBuffer::new();
-//! let x = 12;
-//! write!(buffer, "{}", x).unwrap();
-//! assert_eq!(buffer.as_str(), "12");
+//! use std::fmt::Write as _;
+//! 
+//! fn main() {
+//!     let mut buffer: WriteBuffer<20> = WriteBuffer::new();
+//!     let x = 12;
+//!     write!(buffer, "{}", x).unwrap();
+//!     assert_eq!(buffer.as_str(), "12");
+//! }
 //! ```
-
 use core::fmt::{self, Display, Formatter};
 
 /// A write buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
 
-//! A no-std `Write`able buffer, to use like
+//! A `no_std`, no allocation, `core::fmt::Write`able buffer.
+//! 
+//! Usage:
 //!
 //! ```
 //! use e_write_buffer::WriteBuffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@
 #![deny(missing_docs)]
 
 //! A `no_std`, no allocation, `core::fmt::Write`able buffer.
-//! 
+//!
 //! Usage:
 //!
 //! ```rs
 //! use e_write_buffer::WriteBuffer;
 //! use std::fmt::Write as _;
-//! 
+//!
 //! fn main() {
 //!     let mut buffer: WriteBuffer<20> = WriteBuffer::new();
 //!     let x = 12;
@@ -19,7 +19,7 @@
 use core::fmt::{self, Display, Formatter};
 
 /// A write buffer
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy)]
 pub struct WriteBuffer<const N: usize> {
     buffer: [u8; N],
     cursor: usize,
@@ -100,6 +100,20 @@ impl<const N: usize> Default for WriteBuffer<N> {
         Self::new()
     }
 }
+
+impl<const N: usize> PartialEq for WriteBuffer<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<const N: usize> core::hash::Hash for WriteBuffer<N> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl<const N: usize> Eq for WriteBuffer<N> {}
 
 impl<const N: usize> fmt::Write for WriteBuffer<N> {
     fn write_str(&mut self, s: &str) -> fmt::Result {


### PR DESCRIPTION
Hi,

I have change `as_str` to use `core::str::from_utf8_unchecked`  instead of `core::str::from_utf8`. Checking for utf8 validity adds runtime overhead and is unnecessary, since the only way to write bytes into the buffer is via `Write::write_str`, where we get a `&str`, which already is guaranteed to be valid utf8. So there is no way for our buffer to ever contain invalid utf8.

I've also added a `as_str_mut` version, in case that is of use to anyone.

And some convenience functions, `is_empty`, `is_full`, `remaining`.

Also a few standard traits (`Clone`, `Copy`, `Eq`, `Hash`).